### PR TITLE
Return response code 500, when rendering error.

### DIFF
--- a/show_errors_middleware.go
+++ b/show_errors_middleware.go
@@ -3,6 +3,7 @@ package web
 import (
 	"bufio"
 	"html/template"
+	"net/http"
 	"os"
 	"runtime"
 	"strings"
@@ -40,6 +41,8 @@ func renderPrettyError(rw ResponseWriter, req *Request, err interface{}, stack [
 	}
 
 	rw.Header().Set("Content-Type", "text/html")
+	rw.WriteHeader(http.StatusInternalServerError)
+
 	tpl := template.Must(template.New("ErrorPage").Parse(panicPageTpl))
 	tpl.Execute(rw, data)
 }


### PR DESCRIPTION
Responses by the ShowErrorsMiddleware returned response code 200, which confused my JavaScript code. The attached commit sets a 500 response code, making sure the error can be correctly handled on the client-side.

This is my second attempt to create a pull request which only contains the relevant changes. I'm sorry for the inconvenience.
