### PR TITLE
Add Godoc reference badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# gocraft/web
+# gocraft/web [![GoDoc](https://godoc.org/github.com/gocraft/web?status.png)](https://godoc.org/github.com/gocraft/web)
+
 
 gocraft/web is a Go mux and middleware package. We deal with casting and reflection so YOUR code can be statically typed. And we're fast.
 


### PR DESCRIPTION
There is no url that links to the godoc documentation in readme. The official badge is simple and also would be helpful for others to go directly to godoc documentation
