### PR TITLE
Added support for HEAD requests.

### DIFF
--- a/router_setup.go
+++ b/router_setup.go
@@ -8,6 +8,7 @@ import (
 type HttpMethod string
 
 const (
+	HttpMethodHead   = HttpMethod("HEAD")
 	HttpMethodGet    = HttpMethod("GET")
 	HttpMethodPost   = HttpMethod("POST")
 	HttpMethodPut    = HttpMethod("PUT")
@@ -136,6 +137,10 @@ func (r *Router) NotFound(fn interface{}) {
 	vfn := reflect.ValueOf(fn)
 	validateNotFoundHandler(vfn, r.contextType)
 	r.notFoundHandler = vfn
+}
+
+func (r *Router) Head(path string, fn interface{}) *Router {
+	return r.addRoute(HttpMethodHead, path, fn)
 }
 
 func (r *Router) Get(path string, fn interface{}) *Router {


### PR DESCRIPTION
HEAD requests are principally useful for testing that an endpoint is reachable (is the server working?) and testing that the parameters passed in a request are coherent (is this a good or a bad request?).

It is important to support HEAD requests, without which the HTTP implementation is not complete.

The Go net/http stack appears to implement HEAD requests via a 'devnull' writer.  This makes it easy for implementers because an existing get-request handler can also be used for the equivalent head-requests.  Response output is sent to the client in the case of GET requests, but dropped in a black hole in the case of HEAD requests; this meets the requirements of the HTTP RFC.
