### PR TITLE
Add option parameter for StaticMiddleware

### DIFF
--- a/static_middleware.go
+++ b/static_middleware.go
@@ -3,12 +3,18 @@ package web
 import (
 	"net/http"
 	"path/filepath"
+	"strings"
 )
+
+type StaticOption struct {
+	Prefix    string
+	IndexFile string
+}
 
 // StaticMiddleware is the same as StaticMiddlewareFromDir, but accepts a
 // path string for backwards compatibility.
-func StaticMiddleware(path string) func(ResponseWriter, *Request, NextMiddlewareFunc) {
-	return StaticMiddlewareFromDir(http.Dir(path))
+func StaticMiddleware(path string, option ...StaticOption) func(ResponseWriter, *Request, NextMiddlewareFunc) {
+	return StaticMiddlewareFromDir(http.Dir(path), option...)
 }
 
 // StaticMiddlewareFromDir returns a middleware that serves static files from the specified http.FileSystem.
@@ -17,7 +23,11 @@ func StaticMiddleware(path string) func(ResponseWriter, *Request, NextMiddleware
 //
 // If a path is requested which maps to a folder with an index.html folder on your filesystem,
 // then that index.html file will be served.
-func StaticMiddlewareFromDir(dir http.FileSystem) func(ResponseWriter, *Request, NextMiddlewareFunc) {
+func StaticMiddlewareFromDir(dir http.FileSystem, options ...StaticOption) func(ResponseWriter, *Request, NextMiddlewareFunc) {
+	var option StaticOption
+	if len(options) > 0 {
+		option = options[0]
+	}
 	return func(w ResponseWriter, req *Request, next NextMiddlewareFunc) {
 		if req.Method != "GET" && req.Method != "HEAD" {
 			next(w, req)
@@ -25,6 +35,14 @@ func StaticMiddlewareFromDir(dir http.FileSystem) func(ResponseWriter, *Request,
 		}
 
 		file := req.URL.Path
+		if option.Prefix != "" {
+			if !strings.HasPrefix(file, option.Prefix) {
+				next(w, req)
+				return
+			}
+			file = file[len(option.Prefix):]
+		}
+
 		f, err := dir.Open(file)
 		if err != nil {
 			next(w, req)
@@ -38,9 +56,9 @@ func StaticMiddlewareFromDir(dir http.FileSystem) func(ResponseWriter, *Request,
 			return
 		}
 
-		// Try to serve index.html
-		if fi.IsDir() {
-			file = filepath.Join(file, "index.html")
+		// Try to serve index
+		if option.IndexFile != "" && fi.IsDir() {
+			file = filepath.Join(file, option.IndexFile)
 			f, err = dir.Open(file)
 			if err != nil {
 				next(w, req)
@@ -54,7 +72,6 @@ func StaticMiddlewareFromDir(dir http.FileSystem) func(ResponseWriter, *Request,
 				return
 			}
 		}
-
 		http.ServeContent(w, req.Request, file, fi.ModTime(), f)
 	}
 }


### PR DESCRIPTION
* StaticOption
    * Prefix : serve static file only when prefixed with this.
               default is ""
    * IndexFile : name of local file to serve when request URL is directory.
                  if its value equals "", middleware dosen't try serve
                  file when request URL is directory