### PR TITLE
Add full path match

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ You can match any route past a certain point like this:
 router.Get("/suggestions/:suggestion_id/comments/:comment_id/:*")
 ```
 
-The path params will contain a “*” member with the rest of your path.
+The path params will contain a “*” member with the rest of your path.  It is illegal to add any more paths past the “*” path param, as it’s meant to match every path afterwards, in all cases.
 
 For Example:
     /suggestions/123/comments/321/foo/879/bar/834

--- a/README.md
+++ b/README.md
@@ -245,6 +245,23 @@ You can also validate the format of your path params with a regexp. For instance
 router.Get("/suggestions/:suggestion_id:\\d.*/comments/:comment_id:\\d.*")
 ```
 
+You can match any route past a certain point like this:
+
+```go
+router.Get("/suggestions/:suggestion_id/comments/:comment_id/:*")
+```
+
+The path params will contain a “*” member with the rest of your path.
+
+For Example:
+    /suggestions/123/comments/321/foo/879/bar/834
+
+Elicits path params:
+    * “suggestion_id”: 123,
+    * “comment_id”: 321,
+    * “*”: “foo/879/bar/834”
+
+
 One thing you CANNOT currently do is use regexps outside of a path segment. For instance, optional path segments are not supported - you would have to define multiple routes that both point to the same handler. This design decision was made to enable efficient routing.
 
 ### Not Found handlers

--- a/routing_test.go
+++ b/routing_test.go
@@ -137,11 +137,26 @@ func TestRoutes(t *testing.T) {
 			get:   "/site2/123/other/OK",
 			vars:  map[string]string{"id": "123", "var": "OK"},
 		},
+		{
+			route: "/site2/:id/:*",
+			get:   "/site2/1abc1/foo/bar/baz/boo",
+			vars:  map[string]string{"id": "1abc1", "*": "foo/bar/baz/boo"},
+		},
+		{
+			route: "/site3/:id:\\d+/:*",
+			get:   "/site3/123/foo/bar/baz/boo",
+			vars:  map[string]string{"id": "123", "*": "foo/bar/baz/boo"},
+		},
+		{
+			route: "/site3/:*",
+			get:   "/site3/foo/bar/baz/boo",
+			vars:  map[string]string{"*": "foo/bar/baz/boo"},
+		},
 	}
 
 	// Create routes
 	for _, rt := range table {
-		// func: ensure closure is created per iteraction (it fails otherwise)
+		//func: ensure closure is created per iteraction (it fails otherwise)
 		func(exp string) {
 			router.Get(rt.route, func(w ResponseWriter, r *Request) {
 				w.Header().Set("X-VARS", stringifyMap(r.PathParams))

--- a/tags
+++ b/tags
@@ -1,0 +1,6 @@
+!_TAG_FILE_FORMAT	2
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted/
+!_TAG_PROGRAM_AUTHOR	Joel Stemmer	/stemmertech@gmail.com/
+!_TAG_PROGRAM_NAME	gotags
+!_TAG_PROGRAM_URL	https://github.com/jstemmer/gotags
+!_TAG_PROGRAM_VERSION	1.3.0

--- a/tags
+++ b/tags
@@ -1,6 +1,0 @@
-!_TAG_FILE_FORMAT	2
-!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted/
-!_TAG_PROGRAM_AUTHOR	Joel Stemmer	/stemmertech@gmail.com/
-!_TAG_PROGRAM_NAME	gotags
-!_TAG_PROGRAM_URL	https://github.com/jstemmer/gotags
-!_TAG_PROGRAM_VERSION	1.3.0

--- a/tree.go
+++ b/tree.go
@@ -54,12 +54,7 @@ func (pn *pathNode) add(path string, route *route) {
 }
 
 func (pn *pathNode) addInternal(segments []string, route *route, wildcards []string, regexps []*regexp.Regexp) {
-	matchesFullPath := false
-	if len(wildcards) > 0 {
-		matchesFullPath = wildcards[len(wildcards)-1] == "*"
-	}
-
-	if len(segments) == 0 || matchesFullPath {
+	if len(segments) == 0 {
 		allNilRegexps := true
 		for _, r := range regexps {
 			if r != nil {
@@ -69,6 +64,11 @@ func (pn *pathNode) addInternal(segments []string, route *route, wildcards []str
 		}
 		if allNilRegexps {
 			regexps = nil
+		}
+
+		matchesFullPath := false
+		if len(wildcards) > 0 {
+			matchesFullPath = wildcards[len(wildcards)-1] == "*"
 		}
 
 		pn.leaves = append(pn.leaves, &pathLeaf{route: route, wildcards: wildcards, regexps: regexps, matchesFullPath: matchesFullPath})

--- a/tree.go
+++ b/tree.go
@@ -134,8 +134,7 @@ func (pn *pathNode) match(segments []string, wildcardValues []string) (leaf *pat
 
 	if leaf == nil && pn.matchesFullPath {
 		for _, leaf := range pn.leaves {
-			if leaf.matchesFullPath {
-				_ = "breakpoint"
+			if leaf.matchesFullPath && leaf.match(wildcardValues) {
 				if len(wildcardValues) > 0 {
 					wcVals := []string{wildcardValues[len(wildcardValues)-1], seg}
 					for _, s := range segments {


### PR DESCRIPTION
@cypriss @assplecake @hoffoo @tyler-smith 

This PR is to allow pattern matching across URL paths in a very restrictive way. I needed to be able to match full URL paths past a certain point.  

I understand that one of the main goals of gocraft/web is to be fast, so I utilized some information gathering whilst building the path tree to cut down on processing time, at a minimal memory cost.  This should have almost no negative impact on performance for people not using the "*" pattern matcher.