### PR TITLE
FEATURE: Automatically handle OPTIONS requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,24 @@ func (c *Context) NotFound(rw web.ResponseWriter, r *web.Request) {
 }
 ```
 
+### OPTIONS handlers
+If an [OPTIONS request](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing#Preflight_example) is made and routes with other methods are found for the requested path, then by default we'll return an empty response with an appropriate `Access-Control-Allow-Methods` header.
+
+You can supply a custom OPTIONS handler on your root router:
+
+```go
+router.OptionsHandler((*Context).OptionsHandler)
+```
+
+Your handler can optionally accept a pointer to the root context. OPTIONS handlers look like this:
+
+```go
+func (c *Context) OptionsHandler(rw web.ResponseWriter, r *web.Request, methods []string) {
+	rw.Header().Add("Access-Control-Allow-Methods", strings.Join(methods, ", "))
+	rw.Header().Add("Access-Control-Allow-Origin", "*")
+}
+```
+
 ### Error handlers
 By default, if there's a panic in middleware or a handler, we'll return a 500 status and render the text "Application Error".
 

--- a/options_handler.go
+++ b/options_handler.go
@@ -1,0 +1,18 @@
+package web
+
+import (
+	"net/http"
+	"reflect"
+	"strings"
+)
+
+func (r *Router) genericOptionsHandler(ctx reflect.Value, methods []string) func(rw ResponseWriter, req *Request) {
+	return func(rw ResponseWriter, req *Request) {
+		if r.optionsHandler.IsValid() {
+			invoke(r.optionsHandler, ctx, []reflect.Value{reflect.ValueOf(rw), reflect.ValueOf(req), reflect.ValueOf(methods)})
+		} else {
+			rw.Header().Add("Access-Control-Allow-Methods", strings.Join(methods, ", "))
+			rw.WriteHeader(http.StatusOK)
+		}
+	}
+}

--- a/options_handler_test.go
+++ b/options_handler_test.go
@@ -1,0 +1,52 @@
+package web
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestOptionsHandler(t *testing.T) {
+	router := New(Context{})
+
+	sub := router.Subrouter(Context{}, "/sub")
+	sub.Middleware(AccessControlMiddleware)
+	sub.Get("/action", (*Context).A)
+	sub.Put("/action", (*Context).A)
+
+	rw, req := newTestRequest("OPTIONS", "/sub/action")
+	router.ServeHTTP(rw, req)
+	assertResponse(t, rw, "", 200)
+	assert.Equal(t, "GET, PUT", rw.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "*", rw.Header().Get("Access-Control-Allow-Origin"))
+
+	rw, req = newTestRequest("GET", "/sub/action")
+	router.ServeHTTP(rw, req)
+	assert.Equal(t, "*", rw.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCustomOptionsHandler(t *testing.T) {
+	router := New(Context{})
+	router.OptionsHandler((*Context).OptionsHandler)
+
+	sub := router.Subrouter(Context{}, "/sub")
+	sub.Middleware(AccessControlMiddleware)
+	sub.Get("/action", (*Context).A)
+	sub.Put("/action", (*Context).A)
+
+	rw, req := newTestRequest("OPTIONS", "/sub/action")
+	router.ServeHTTP(rw, req)
+	assertResponse(t, rw, "", 200)
+	assert.Equal(t, "GET, PUT", rw.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "100", rw.Header().Get("Access-Control-Max-Age"))
+}
+
+func (c *Context) OptionsHandler(rw ResponseWriter, req *Request, methods []string) {
+	rw.Header().Add("Access-Control-Allow-Methods", strings.Join(methods, ", "))
+	rw.Header().Add("Access-Control-Max-Age", "100")
+}
+
+func AccessControlMiddleware(rw ResponseWriter, req *Request, next NextMiddlewareFunc) {
+	rw.Header().Add("Access-Control-Allow-Origin", "*")
+	next(rw, req)
+}

--- a/router_setup.go
+++ b/router_setup.go
@@ -8,13 +8,13 @@ import (
 type httpMethod string
 
 const (
-	httpMethodGet    = httpMethod("GET")
-	httpMethodPost   = httpMethod("POST")
-	httpMethodPut    = httpMethod("PUT")
-	httpMethodDelete = httpMethod("DELETE")
-	httpMethodPatch  = httpMethod("PATCH")
-	httpMethodHead   = httpMethod("HEAD")
-	httpMethodOptions   = httpMethod("OPTIONS")
+	httpMethodGet     = httpMethod("GET")
+	httpMethodPost    = httpMethod("POST")
+	httpMethodPut     = httpMethod("PUT")
+	httpMethodDelete  = httpMethod("DELETE")
+	httpMethodPatch   = httpMethod("PATCH")
+	httpMethodHead    = httpMethod("HEAD")
+	httpMethodOptions = httpMethod("OPTIONS")
 )
 
 var httpMethods = []httpMethod{httpMethodGet, httpMethodPost, httpMethodPut, httpMethodDelete, httpMethodPatch, httpMethodHead, httpMethodOptions}
@@ -45,6 +45,9 @@ type Router struct {
 	// This can only be set on the root handler, since by virtue of not finding a route, we don't have a target.
 	// (That being said, in the future we could investigate namespace matches)
 	notFoundHandler reflect.Value
+
+	// This can only be set on the root handler, since by virtue of not finding a route, we don't have a target.
+	optionsHandler reflect.Value
 }
 
 // NextMiddlewareFunc are functions passed into your middleware. To advance the middleware, call the function.
@@ -168,6 +171,18 @@ func (r *Router) NotFound(fn interface{}) *Router {
 	return r
 }
 
+// NotFound sets the specified function as the not-found handler (when no route matches) and returns the router.
+// Note that only the root router can have a NotFound handler.
+func (r *Router) OptionsHandler(fn interface{}) *Router {
+	if r.parent != nil {
+		panic("You can only set an OptionsHandler on the root router.")
+	}
+	vfn := reflect.ValueOf(fn)
+	validateOptionsHandler(vfn, r.contextType)
+	r.optionsHandler = vfn
+	return r
+}
+
 // Get will add a route to the router that matches on GET requests and the specified path.
 func (r *Router) Get(path string, fn interface{}) *Router {
 	return r.addRoute(httpMethodGet, path, fn)
@@ -279,6 +294,15 @@ func validateNotFoundHandler(vfn reflect.Value, ctxType reflect.Type) {
 	var resp func() ResponseWriter
 	if !isValidHandler(vfn, ctxType, reflect.TypeOf(resp).Out(0), reflect.TypeOf(req)) {
 		panic(instructiveMessage(vfn, "a 'not found' handler", "not found handler", "rw web.ResponseWriter, req *web.Request", ctxType))
+	}
+}
+
+func validateOptionsHandler(vfn reflect.Value, ctxType reflect.Type) {
+	var req *Request
+	var resp func() ResponseWriter
+	var methods []string
+	if !isValidHandler(vfn, ctxType, reflect.TypeOf(resp).Out(0), reflect.TypeOf(req), reflect.TypeOf(methods)) {
+		panic(instructiveMessage(vfn, "an 'options' handler", "options handler", "rw web.ResponseWriter, req *web.Request, methods []string", ctxType))
 	}
 }
 


### PR DESCRIPTION
New approach:
* OPTIONS routes are created on the fly as needed (and discarded), so we no longer have a conflict with individual `Options` handlers.
* There is a generic `RootRouter.optionsHandler` that you can override if you want to set other headers.
* Unfortunately, the method to set the options handler has to be `OptionsHandler()` rather than just `Options()` (to match `NotFound()`) since the latter name is already taken by the http verb.
* We could potentially add OPTIONS routes to the routes tree once they are called the first time, but I opted not to do this.