### PR TITLE
Proposed fix for issue #49 [Issue with StaticMiddleWare]

### DIFF
--- a/static_middleware.go
+++ b/static_middleware.go
@@ -56,18 +56,26 @@ func StaticMiddlewareFromDir(dir http.FileSystem, options ...StaticOption) func(
 			return
 		}
 
-		// Try to serve index
-		if option.IndexFile != "" && fi.IsDir() {
-			file = filepath.Join(file, option.IndexFile)
-			f, err = dir.Open(file)
-			if err != nil {
-				next(w, req)
-				return
-			}
-			defer f.Close()
+		// If the file is a directory, try to serve an index file.
+		// If no index is available, DO NOT serve the directory to avoid
+		// Content-Length issues. Simply skip to the next middleware, and return
+		// a 404 if no path with the same name is handled. 
+		if fi.IsDir() {
+			if option.IndexFile != "" {
+				file = filepath.Join(file, option.IndexFile)
+				f, err = dir.Open(file)
+				if err != nil {
+					next(w, req)
+					return
+				}
+				defer f.Close()
 
-			fi, err = f.Stat()
-			if err != nil || fi.IsDir() {
+				fi, err = f.Stat()
+				if err != nil || fi.IsDir() {
+					next(w, req)
+					return
+				}
+			} else {
 				next(w, req)
 				return
 			}

--- a/static_middleware.go
+++ b/static_middleware.go
@@ -59,7 +59,7 @@ func StaticMiddlewareFromDir(dir http.FileSystem, options ...StaticOption) func(
 		// If the file is a directory, try to serve an index file.
 		// If no index is available, DO NOT serve the directory to avoid
 		// Content-Length issues. Simply skip to the next middleware, and return
-		// a 404 if no path with the same name is handled. 
+		// a 404 if no route with the same name is handled. 
 		if fi.IsDir() {
 			if option.IndexFile != "" {
 				file = filepath.Join(file, option.IndexFile)


### PR DESCRIPTION
[**_Link to the open issue_**](https://github.com/gocraft/web/issues/49)

**Problem**: when using StaticMiddleware, if the URL of a directory without a specified index file is requested (most notably, "/"), the router tries to serve the directory itself, which causes the Content-Length of the header to explode (9223372036854775807) and the client to drop the connections.

**Proposed fix**: when an index file is not specified, **DO NOT** serve the directory, and just skip to the next middleware. If no route with the same name of the directory is not handled in the router, a 404 error will be returned. This also allows for custom behavior when handling directories.

Regards.